### PR TITLE
Fix:  submitFile and registerDevice APIs not properly destructuring request headers

### DIFF
--- a/src/controllers/Device/index.ts
+++ b/src/controllers/Device/index.ts
@@ -444,7 +444,8 @@ export const ping  = async (req: Request, res: Response) => {
 export const submitFile  = async (req: Request, res: Response) => {
 
     const { deviceID } = req.params;
-    const { DeviceModelName, DeviceModelVersion } = req.headers;
+    const DeviceModelName = req.header('DeviceModelName');
+    const DeviceModelVersion = req.header('DeviceModelVersion');
     const requestBody = req.body;
 
     if (!requestBody.content) {

--- a/src/controllers/Public/index.ts
+++ b/src/controllers/Public/index.ts
@@ -13,7 +13,8 @@ import generateOperationID from '../../utils/generateOperationID';
 
 export const registerDevice  = async (req: Request, res: Response) => {
     const { deviceID } = req.params;
-    const { DeviceModelName, DeviceModelVersion } = req.headers;
+    const DeviceModelName = req.header('DeviceModelName');
+    const DeviceModelVersion = req.header('DeviceModelVersion');
     const requestBody = req.body;
   
     if (!deviceID || isNaN(Number(deviceID))) {
@@ -39,7 +40,7 @@ export const registerDevice  = async (req: Request, res: Response) => {
     }
   
     if (!requestBody || !requestBody.activationKey || !requestBody.certificateRequest || requestBody.certificateRequest == "invalid" 
-        || requestBody.activationKey != "invalid")  {
+        || requestBody.activationKey == "invalid")  {
       return res.status(422).json({
         errorCode: "DEV01",
         type: "https://httpstatuses.io/422",
@@ -136,7 +137,7 @@ export const verifyTaxpayerInformation  = async (req: Request, res: Response) =>
     }
 
     if (!requestBody || !requestBody.activationKey || !requestBody.deviceSerialNo || requestBody.deviceSerialNo == "invalid"
-        || requestBody.activationKey != "invalid") {
+        || requestBody.activationKey == "invalid") {
         return res.status(422).json({
             errorCode: "DEV01",
             type: "https://httpstatuses.io/422",

--- a/src/controllers/Public/index.ts
+++ b/src/controllers/Public/index.ts
@@ -40,7 +40,7 @@ export const registerDevice  = async (req: Request, res: Response) => {
     }
   
     if (!requestBody || !requestBody.activationKey || !requestBody.certificateRequest || requestBody.certificateRequest == "invalid" 
-        || requestBody.activationKey == "invalid")  {
+        || requestBody.activationKey === "invalid")  {
       return res.status(422).json({
         errorCode: "DEV01",
         type: "https://httpstatuses.io/422",
@@ -137,7 +137,7 @@ export const verifyTaxpayerInformation  = async (req: Request, res: Response) =>
     }
 
     if (!requestBody || !requestBody.activationKey || !requestBody.deviceSerialNo || requestBody.deviceSerialNo == "invalid"
-        || requestBody.activationKey == "invalid") {
+        || requestBody.activationKey === "invalid") {
         return res.status(422).json({
             errorCode: "DEV01",
             type: "https://httpstatuses.io/422",


### PR DESCRIPTION
Good day Taku

I wish to propose a pull request.

### 1. Setting Headers Explicitly for submitFile  and registerDevice 

When invoking the `submitFile` API under Device and `registerDevice` under Public,  it  gives HTTP Status code `400 Bad Request` even with headers correct set. This is because when Express parses incoming headers, it automatically converts all header names to lowercase. So if you send headers as `DeviceModelName` and `DeviceModelVersion`, they will actually appear in `req.headers` as `devicemodelname` and `devicemodelversion`. 

Using this destructuring:
```javascript
 const { DeviceModelName, DeviceModelVersion } = req.headers;
``` 
won’t work because those exact keys don’t exist (they are now lowercase).
i suggest to use Express’s helper method which is case-insensitive,  like in the other APIs
```javascript
const DeviceModelName = req.header('DeviceModelName');
const DeviceModelVersion = req.header('DeviceModelVersion');
```

Alternatively, we can destructure with the lowercase keys and alias them:

```javascript
const { devicemodelname: DeviceModelName, devicemodelversion: DeviceModelVersion } = req.headers;
```
 After doing so , when invoking the APIs I was able to get `HTTP Status 200 OK`.

### 2. Conditional for the registerDevice and the verifyTaxpayerInformation APIs under Public controller

The conditional 
```javascript

if (!requestBody || !requestBody.activationKey || !requestBody.deviceSerialNo || requestBody.deviceSerialNo == "invalid"
        || requestBody.activationKey != "invalid") {
        return res.status(422).json({
            errorCode: "DEV01",
            type: "https://httpstatuses.io/422",
            title: "Unprocessable Entity",
            status: 422,
            detail: "Device not found or not active",
            operationID
        });
```

 I believe we should be checking if `requestBody.activationKey === "invalid"` then return status `422`.

Looking forward to your feedback. Great project Taku


